### PR TITLE
Integrate RabbitMQ messaging into document workflow

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,10 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/Application/Messaging/NoOpDocumentQueuePublisher.cs
+++ b/Application/Messaging/NoOpDocumentQueuePublisher.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+
+namespace Application.Messaging;
+
+public sealed class NoOpDocumentQueuePublisher(ILogger<NoOpDocumentQueuePublisher> logger) : IDocumentQueuePublisher
+{
+    public Task PublishDocumentUploadedAsync(DocumentUploadedMessage message, CancellationToken ct = default)
+    {
+        if (ct.IsCancellationRequested)
+            return Task.FromCanceled(ct);
+
+        logger.LogInformation("Skipping queue publish for document {DocumentId} in testing environment", message.DocumentId);
+        return Task.CompletedTask;
+    }
+}

--- a/DMS_SWEN3/appsettings.json
+++ b/DMS_SWEN3/appsettings.json
@@ -5,5 +5,13 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "RabbitMq": {
+    "HostName": "localhost",
+    "Port": 5672,
+    "VirtualHost": "/",
+    "UserName": "guest",
+    "Password": "guest",
+    "QueueName": "documents.uploaded"
+  }
 }

--- a/Infrastructure/Messaging/RabbitMqDocumentPublisher.cs
+++ b/Infrastructure/Messaging/RabbitMqDocumentPublisher.cs
@@ -1,9 +1,9 @@
-﻿namespace Infrastructure.Messaging;
+namespace Infrastructure.Messaging;
 
 using System.Text;
 using System.Text.Json;
 using Application.Messaging;
-using Exceptions;
+using Infrastructure.Exceptions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RabbitMQ.Client;

--- a/OcrWorker/QueueWorker.cs
+++ b/OcrWorker/QueueWorker.cs
@@ -1,7 +1,6 @@
-﻿using System.Text;
+using System.Text;
 using System.Threading;
 using Infrastructure.Messaging;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,8 +32,16 @@ public sealed class QueueWorker : BackgroundService
         _logger.LogInformation("Starting OCR worker listening to queue {Queue}", _options.QueueName);
         stoppingToken.Register(DisposeResources);
 
-        _connection = _connectionFactory.CreateConnection();
-        _channel = _connection.CreateModel();
+        try
+        {
+            _connection = _connectionFactory.CreateConnection();
+            _channel = _connection.CreateModel();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogCritical(ex, "Unable to establish RabbitMQ connection");
+            throw;
+        }
         _channel.QueueDeclare(queue: _options.QueueName, durable: true, exclusive: false, autoDelete: false);
 
         var consumer = new AsyncEventingBasicConsumer(_channel);

--- a/OcrWorker/RabbitConnectionFactory.cs
+++ b/OcrWorker/RabbitConnectionFactory.cs
@@ -1,4 +1,4 @@
-﻿using Infrastructure.Messaging;
+using Infrastructure.Messaging;
 using Microsoft.Extensions.Options;
 using RabbitMQ.Client;
 

--- a/OcrWorker/appsettings.json
+++ b/OcrWorker/appsettings.json
@@ -4,5 +4,13 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "RabbitMq": {
+    "HostName": "localhost",
+    "Port": 5672,
+    "VirtualHost": "/",
+    "UserName": "guest",
+    "Password": "guest",
+    "QueueName": "documents.uploaded"
   }
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-﻿services:
+services:
   dms_swen3:
     image: dms_swen3
     build:
@@ -7,10 +7,18 @@
     depends_on:
       postgres:
         condition: service_healthy
+      rabbitmq:
+        condition: service_started
     environment:
       - ASPNETCORE_URLS=http://+:8080
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=${POSTGRES_PORT};Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
       - ASPNETCORE_ENVIRONMENT=Development
+      - RabbitMq__HostName=rabbitmq
+      - RabbitMq__Port=5672
+      - RabbitMq__VirtualHost=/
+      - RabbitMq__UserName=${RABBITMQ_DEFAULT_USER}
+      - RabbitMq__Password=${RABBITMQ_DEFAULT_PASS}
+      - RabbitMq__QueueName=documents.uploaded
     networks: [backend]
     restart: unless-stopped
 
@@ -112,12 +120,32 @@
     networks: [backend, edge]
     image: rabbitmq:4.1-management
     ports:
-    - "127.0.0.1:15672:15672"
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+    restart: unless-stopped
+
+  ocr_worker:
+    image: dms_ocr_worker
+    build:
+      context: ./OcrWorker
+      dockerfile: Dockerfile
+    depends_on:
+      rabbitmq:
+        condition: service_started
+    environment:
+      - DOTNET_ENVIRONMENT=Development
+      - RabbitMq__HostName=rabbitmq
+      - RabbitMq__Port=5672
+      - RabbitMq__VirtualHost=/
+      - RabbitMq__UserName=${RABBITMQ_DEFAULT_USER}
+      - RabbitMq__Password=${RABBITMQ_DEFAULT_PASS}
+      - RabbitMq__QueueName=documents.uploaded
+    networks: [backend]
     restart: unless-stopped
 
 networks:


### PR DESCRIPTION
## Summary
- add RabbitMQ and OCR worker containers with appropriate environment wiring
- configure the API to publish document upload messages, include a no-op publisher for tests, and expose the /health endpoint
- extend configuration and worker logic to handle RabbitMQ connectivity and logging concerns

## Testing
- Not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e6626611488323b3c4054fb8236b6f